### PR TITLE
fix: keep order during groupBy

### DIFF
--- a/packages/ali-react-table/src/pivot/pivot-utils/buildDrillTree.ts
+++ b/packages/ali-react-table/src/pivot/pivot-utils/buildDrillTree.ts
@@ -1,4 +1,4 @@
-import { groupBy } from '../../utils'
+import { groupBy2 } from '../../utils'
 import { always } from '../../utils/others'
 import { DrillNode } from './interfaces'
 import simpleEncode from './simpleEncode'
@@ -78,8 +78,8 @@ export default function buildDrillTree(
     const depth = path.length
     const array: DrillNode[] = []
     const code = codes[depth]
-    const groups = groupBy(slice, (row) => row[code])
-    for (const groupKey of Object.keys(groups)) {
+    const groups = groupBy2(slice, (row) => row[code])
+    for (const groupKey of groups.keys()) {
       path.push(groupKey)
 
       const node: DrillNode = {
@@ -89,7 +89,7 @@ export default function buildDrillTree(
       }
       array.push(node)
 
-      const group = groups[groupKey]
+      const group = groups.get(groupKey)
       if (group.length > 0 && depth < codes.length - 1) {
         if (isExpand(node.key)) {
           node.children = dfs(group, path)

--- a/packages/ali-react-table/src/pivot/pivot-utils/builders.ts
+++ b/packages/ali-react-table/src/pivot/pivot-utils/builders.ts
@@ -1,4 +1,4 @@
-import { groupBy, isLeafNode } from '../../utils'
+import { groupBy2, isLeafNode } from '../../utils'
 import { always, fromEntries } from '../../utils/others'
 import buildDrillTree from './buildDrillTree'
 import { DrillNode, RecordMatrix } from './interfaces'
@@ -81,11 +81,11 @@ export function buildRecordMatrix({
     } else {
       children = []
       const code = leftCodes[depth]
-      const groups = groupBy(slice, (dwdRow) => dwdRow[code])
+      const groups = groupBy2(slice, (dwdRow) => dwdRow[code])
 
       ctx.peculiarity.add(code)
       for (const child of drillNode.children) {
-        const group = groups[child.value]
+        const group = groups.get(child.value)
         if (group) {
           children.push(buildByLeft(ctx, group, child, depth + 1))
         }
@@ -114,10 +114,10 @@ export function buildRecordMatrix({
     } else {
       children = []
       const code = topCodes[depth]
-      const groups = groupBy(slice, (dwdRow) => dwdRow[code])
+      const groups = groupBy2(slice, (dwdRow) => dwdRow[code])
       ctx.peculiarity.add(code)
       for (const child of drillNode.children) {
-        const group = groups[child.value]
+        const group = groups.get(child.value)
         if (group) {
           children.push(buildByTop(ctx, group, child, depth + 1))
         }

--- a/packages/ali-react-table/src/utils/groupBy2.ts
+++ b/packages/ali-react-table/src/utils/groupBy2.ts
@@ -1,0 +1,12 @@
+export default function groupBy2<T, K extends string | number>(list: T[], iteratee: (t: T) => K) {
+  const groups = new Map<K, T[]>()
+
+  for (const item of list) {
+    const key = iteratee(item)
+    if (!groups.has(key)) {
+      groups.set(key, [])
+    }
+    groups.get(key).push(item)
+  }
+  return groups
+}

--- a/packages/ali-react-table/src/utils/index.tsx
+++ b/packages/ali-react-table/src/utils/index.tsx
@@ -1,6 +1,7 @@
 export { default as collectNodes } from './collectNodes'
 export { default as getTreeDepth } from './getTreeDepth'
 export { default as groupBy } from './groupBy'
+export { default as groupBy2 } from './groupBy2'
 export { default as isLeafNode } from './isLeafNode'
 export { default as applyTransforms } from './applyTransforms'
 export { default as buildTree } from './buildTree'

--- a/packages/website/docs/tools/utils.mdx
+++ b/packages/website/docs/tools/utils.mdx
@@ -10,7 +10,7 @@ title: 通用工具函数
 ### `applyTransforms`
 
 :::note deprecated
-表格功能拓展(transforms) 已经过时，所以一般情况下你不再使用该 API 了。
+表格功能拓展(transforms) 已经过时，API 也不应被使用了。
 :::
 
 API: `function applyTransforms<T>(input: T, ...transforms: Transform<T>[]): T`
@@ -155,6 +155,12 @@ API: `function getTreeDepth(nodes: AbstractTreeNode[]): number`
 API: `function groupBy<T, K extends string>(list: T[], iteratee: (t: T) => K): { [key in K]: T[] }`
 
 对 list 中的元素进行分组，iteratee 的返回值相同的元素将被分到同一个分组。
+
+### `groupBy2`
+
+API: `function groupBy2<T, K extends string | number>(list: T[], iteratee: (t: T) => K): Map<K, T>`
+
+与 groupBy 作用相同，但会使用 Map 作为返回结果，并尽量保持数据的原始顺序。
 
 ### `isLeafNode`
 


### PR DESCRIPTION
修复 buildDrillTree 和 buildRecordMatrix 导致数据顺序改变的问题

close #168
close #195 