### PR TITLE
fix: 自定义详情单元格样式不生效 ‘detailCellStyle’

### DIFF
--- a/packages/ali-react-table/src/pipeline/features/rowDetail.tsx
+++ b/packages/ali-react-table/src/pipeline/features/rowDetail.tsx
@@ -202,7 +202,14 @@ export function rowDetail(opts: RowDetailFeatureOptions = {}) {
             </div>
           ),
           render,
-          getCellProps: clickArea === 'cell' ? getCellProps : firstCol.getCellProps,
+          // getCellProps: clickArea === 'cell' ? getCellProps : firstCol.getCellProps,
+          getCellProps: (value: any, row: any, rowIndex: number)=>{
+            if (row[rowDetailMetaKey] || clickArea === 'cell') {
+              return getCellProps(value, row, rowIndex);
+            }else{
+              return firstCol.getCellProps?.(value, row, rowIndex);
+            }
+          },
           getSpanRect(value: any, row: any, rowIndex: number) {
             if (row[rowDetailMetaKey]) {
               // detail 总是成一行


### PR DESCRIPTION
之前逻辑，如果 `clickArea` 的值不是 ‘cell’ ，自定义详情单元格样式 ‘detailCellStyle’ 不生效