### PR TITLE
fix: react18 createRoot渲染模式，严格模式下，渲染错误问题

### DIFF
--- a/packages/ali-react-table/src/base-table/table.tsx
+++ b/packages/ali-react-table/src/base-table/table.tsx
@@ -468,6 +468,7 @@ export class BaseTable extends React.Component<BaseTableProps, BaseTableState> {
   }
 
   componentDidMount() {
+    this.rootSubscription = new Subscription()
     this.updateDOMHelper()
     this.props$ = new BehaviorSubject(this.props)
     this.initSubscriptions()


### PR DESCRIPTION
在react18版本，使用BaseTable, 用createRoot方式渲染，App被严格模式包裹时，会导致组件无法正确渲染
```
import ReactDOM from "react-dom/client";
const root = ReactDOM.createRoot(
  document.getElementById("root") as HTMLElement
);
root.render(
  <React.StrictMode>
    <App />
  </React.StrictMode>
);
```

由于react18在严格模式下，对于类组件会先调用一次 componentWillUnmount, 导致rootSubscription被取消订阅
![image](https://github.com/alibaba/ali-react-table/assets/58944410/4bc78f73-ce48-47ef-92ff-921ac425e102)
